### PR TITLE
Fix Issue #10: Add Number of Days to keep in History in Settings

### DIFF
--- a/calc.py
+++ b/calc.py
@@ -99,6 +99,15 @@ class SettingsScreen:
             "angle_unit"
         )
 
+        # History retention days
+        self._add_section_label(content, "History")
+        self._add_spinbox_row(
+            content, "Keep history for (days)",
+            1, 365,
+            self.settings.get("history_retention_days", 30),
+            "history_retention_days"
+        )
+
         # Save button
         save_btn = tk.Button(
             self.window, text="Save", bg=LIGHT_BLUE, fg=LABEL_COLOR,
@@ -174,7 +183,7 @@ class SettingsScreen:
 
     def _save(self):
         # Sync spinbox value (Spinbox command fires before value updates)
-        for key in ("decimal_precision",):
+        for key in ("decimal_precision", "history_retention_days"):
             var = getattr(self, f"_var_{key}", None)
             if var:
                 try:

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -245,6 +245,16 @@ class TestSettingsScreen(unittest.TestCase):
         
         self.assertEqual(screen.settings['decimal_precision'], 8)
 
+    def test_settings_screen_history_retention_in_settings(self):
+        """Test that history retention is included in settings."""
+        settings = {'theme': 'Light', 'history_retention_days': 30}
+        on_save_callback = mock.MagicMock()
+        
+        screen = self.calc.SettingsScreen(None, settings, on_save_callback)
+        
+        # Verify history_retention_days is in settings
+        self.assertIn('history_retention_days', screen.settings)
+
 
 class TestTheme(unittest.TestCase):
     """Test theme functionality."""


### PR DESCRIPTION
## Summary
Fixes Issue #10: Add Number of Days to keep in History in Settings

## Changes
- Add History section with spinbox for retention days (1-365) in SettingsScreen
- Update _save method to handle history_retention_days setting
- The functionality already exists - `purge_old_history()` runs on app startup
- Add unit test for history retention setting

## Testing
All 14 tests pass.